### PR TITLE
feat: Refactor header for centered title and add admin link

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -33,8 +33,8 @@ hr {
 }
 
 .app-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr; /* 3-column layout */
   align-items: center;
   padding: 1rem 2rem;
   background-color: #fff;
@@ -44,10 +44,21 @@ hr {
   z-index: 50;
 }
 
-.logo-title {
+.header-left {
   display: flex;
+  justify-content: flex-start; /* Aligns logo to the left */
+}
+
+.header-center {
+  display: flex;
+  justify-content: center; /* Centers title */
+}
+
+.header-right {
+  display: flex;
+  justify-content: flex-end; /* Aligns controls to the right */
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 .logo {
@@ -58,6 +69,26 @@ hr {
   font-size: 1.5rem;
   font-weight: 600;
   margin: 0;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.admin-link {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #333;
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.admin-link:hover {
+  background-color: #f0f0f0;
 }
 
 .app-content {
@@ -93,6 +124,17 @@ hr {
   border-radius: 12px;
   box-shadow: 0 8px 16px rgba(0,0,0,0.05);
   border: 1px solid #e5e7eb;
+}
+
+.admin-layout {
+  display: flex;
+  flex: 1;
+  width: 100%;
+}
+
+.admin-content {
+    flex: 1;
+    /* The padding is handled by main-content now */
 }
 
 /* ==========================================================================
@@ -237,6 +279,14 @@ body.dark-mode {
 .dark-mode .admin-menu li a:hover, .dark-mode .admin-menu li a.active {
   background: #374151;
   color: #fff;
+}
+
+.dark-mode .admin-link {
+    color: #e0e0e0;
+}
+
+.dark-mode .admin-link:hover {
+    background-color: #374151;
 }
 
 /* --- Responsive SideNav --- */

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'; // Import Link
 import FileUpload from './components/FileUpload';
 import FileList from './components/FileList';
 import DarkModeToggle from './components/DarkModeToggle';
@@ -8,7 +8,6 @@ import Dashboard from './components/admin/Dashboard';
 import LogViewer from './components/admin/LogViewer';
 import Quarantine from './components/admin/Quarantine';
 import ConfigPanel from './components/admin/ConfigPanel';
-import SideNav from './components/admin/SideNav';
 import SsoStatusBanner from './components/SsoStatusBanner'; // Corrected import
 import MaintenanceModeBanner from './components/MaintenanceModeBanner';
 import './App.css';
@@ -255,14 +254,18 @@ function App() {
           {isMaintenanceMode && <MaintenanceModeBanner isActive={isMaintenanceMode} />}
         </div>
         <header className="app-header" style={{ top: bannerHeight }}>
-          <div className="logo-title">
+          <div className="header-left">
             <img src="/logo-placeholder.svg" alt="Logo" className="logo" />
+          </div>
+          <div className="header-center">
             <h1 className="app-title">cfiles</h1>
           </div>
-          <DarkModeToggle onChange={toggleDarkMode} isDarkMode={isDarkMode} />
+          <div className="header-right">
+            <Link to="/admin" className="admin-link">Admin</Link>
+            <DarkModeToggle onChange={toggleDarkMode} isDarkMode={isDarkMode} />
+          </div>
         </header>
         <div className="app-content">
-          <SideNav />
           {mainContent}
         </div>
       </div>

--- a/frontend/src/components/admin/AdminLayout.js
+++ b/frontend/src/components/admin/AdminLayout.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import SideNav from './SideNav';
 
 const AdminLayout = () => {
     return (
         <div className="admin-layout">
+            <SideNav />
             <main className="admin-content">
                 <Outlet />
             </main>


### PR DESCRIPTION
- Restructure App.js header with left, center, and right sections.
- Update App.css to use a 3-column grid layout for the header, ensuring the title is always centered.
- Add a permanent 'Admin' link to the header for easy access to the admin panel.
- Style the admin link to match the UI, including hover and dark mode states.